### PR TITLE
feat: support gateway intents

### DIFF
--- a/client.go
+++ b/client.go
@@ -29,12 +29,13 @@ type DiscordClient struct {
 	args        []interface{}
 	messageChan chan Message
 
-	Session     *discordgo.Session
-	User        *discordgo.User
-	Sessions    []*discordgo.Session
-	OwnerUserID string
-	ClientID    string
-	AllowBots   bool
+	Session        *discordgo.Session
+	User           *discordgo.User
+	Sessions       []*discordgo.Session
+	OwnerUserID    string
+	ClientID       string
+	AllowBots      bool
+	GatewayIntents *discordgo.Intent
 }
 
 var channelIDRegex = regexp.MustCompile("<#[0-9]*>")
@@ -219,6 +220,7 @@ func (d *DiscordClient) shardListenConfigureSession(s *discordgo.Session, shardC
 	s.AddHandler(d.onMessageUpdate)
 	s.AddHandler(d.onMessageDelete)
 	s.State.TrackPresences = false
+	s.Identify.Intents = d.GatewayIntents
 
 	return s.Open()
 }

--- a/discordclient.go
+++ b/discordclient.go
@@ -1,11 +1,14 @@
 package discordclient
 
+import "github.com/bwmarrin/discordgo"
+
 // NewDiscordClient returns a new instance of DiscordClient
 func NewDiscordClient(discordToken string, ownerClientID string, discordClientID string) *DiscordClient {
 	return &DiscordClient{
-		args:        []interface{}{("Bot " + discordToken)},
-		messageChan: make(chan Message, 200),
-		OwnerUserID: ownerClientID,
-		ClientID:    discordClientID,
+		args:           []interface{}{("Bot " + discordToken)},
+		messageChan:    make(chan Message, 200),
+		OwnerUserID:    ownerClientID,
+		ClientID:       discordClientID,
+		GatewayIntents: discordgo.MakeIntent(discordgo.IntentsAll),
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/lampjaw/discordclient
 
 go 1.12
 
-require github.com/bwmarrin/discordgo v0.20.1
+require github.com/bwmarrin/discordgo v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/bwmarrin/discordgo v0.20.1 h1:Ihh3/mVoRwy3otmaoPDUioILBJq4fdWkpsi83oj2Lmk=
 github.com/bwmarrin/discordgo v0.20.1/go.mod h1:O9S4p+ofTFwB02em7jkpkV8M3R0/PUVOwN61zSZ0r4Q=
+github.com/bwmarrin/discordgo v0.22.0 h1:uBxY1HmlVCsW1IuaPjpCGT6A2DBwRn0nvOguQIxDdFM=
+github.com/bwmarrin/discordgo v0.22.0/go.mod h1:c1WtWUGN6nREDmzIpyTp/iD3VYt4Fpx+bVyfBG7JE+M=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16 h1:y6ce7gCWtnH+m3dCjzQ1PCuwl28DDIc3VNnvY29DlIA=


### PR DESCRIPTION
**WHAT**

- Adds DiscordClient.GatewayIntents field, defaulting to All (which can be bad behavior, but is least breaking change until October)
  - This field sets the Intents on every shard client.
- Updates discordgo to 0.22.0

**WHY**

- Gateway intents are the required future.