### PR TITLE
Gateway Intents

### DIFF
--- a/client.go
+++ b/client.go
@@ -29,12 +29,13 @@ type DiscordClient struct {
 	args        []interface{}
 	messageChan chan Message
 
-	Session     *discordgo.Session
-	User        *discordgo.User
-	Sessions    []*discordgo.Session
-	OwnerUserID string
-	ClientID    string
-	AllowBots   bool
+	Session        *discordgo.Session
+	User           *discordgo.User
+	Sessions       []*discordgo.Session
+	OwnerUserID    string
+	ClientID       string
+	AllowBots      bool
+	GatewayIntents discordgo.Intent
 }
 
 var channelIDRegex = regexp.MustCompile("<#[0-9]*>")
@@ -162,6 +163,7 @@ func (d *DiscordClient) Listen(shardCount int) (<-chan Message, error) {
 			}
 		}
 
+		d.attachGatewayIntents(d.Session)
 		s, err := d.Session.GatewayBot()
 		if err != nil {
 			return nil, err
@@ -219,8 +221,13 @@ func (d *DiscordClient) shardListenConfigureSession(s *discordgo.Session, shardC
 	s.AddHandler(d.onMessageUpdate)
 	s.AddHandler(d.onMessageDelete)
 	s.State.TrackPresences = false
+	d.attachGatewayIntents(s)
 
 	return s.Open()
+}
+
+func (d *DiscordClient) attachGatewayIntents(s *discordgo.Session) {
+	s.Identify.Intents = discordgo.MakeIntent(d.GatewayIntents)
 }
 
 // IsMe checks if the message has the same id as this session

--- a/discordclient.go
+++ b/discordclient.go
@@ -1,11 +1,14 @@
 package discordclient
 
+import "github.com/bwmarrin/discordgo"
+
 // NewDiscordClient returns a new instance of DiscordClient
 func NewDiscordClient(discordToken string, ownerClientID string, discordClientID string) *DiscordClient {
 	return &DiscordClient{
-		args:        []interface{}{("Bot " + discordToken)},
-		messageChan: make(chan Message, 200),
-		OwnerUserID: ownerClientID,
-		ClientID:    discordClientID,
+		args:           []interface{}{("Bot " + discordToken)},
+		messageChan:    make(chan Message, 200),
+		OwnerUserID:    ownerClientID,
+		ClientID:       discordClientID,
+		GatewayIntents: discordgo.IntentsAllWithoutPrivileged,
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/lampjaw/discordclient
 
-go 1.12
+go 1.15
 
-require github.com/bwmarrin/discordgo v0.20.1
+require github.com/bwmarrin/discordgo v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bwmarrin/discordgo v0.20.1 h1:Ihh3/mVoRwy3otmaoPDUioILBJq4fdWkpsi83oj2Lmk=
-github.com/bwmarrin/discordgo v0.20.1/go.mod h1:O9S4p+ofTFwB02em7jkpkV8M3R0/PUVOwN61zSZ0r4Q=
+github.com/bwmarrin/discordgo v0.22.0 h1:uBxY1HmlVCsW1IuaPjpCGT6A2DBwRn0nvOguQIxDdFM=
+github.com/bwmarrin/discordgo v0.22.0/go.mod h1:c1WtWUGN6nREDmzIpyTp/iD3VYt4Fpx+bVyfBG7JE+M=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16 h1:y6ce7gCWtnH+m3dCjzQ1PCuwl28DDIc3VNnvY29DlIA=


### PR DESCRIPTION
**WHAT**
- Adds `DiscordClient.GatewayIntents` field
  - Defaults to "All" without privileged intents
- Updates discordgo to v0.22.0

**WHY**
- Gateway Intents are a future requirement for Discord bots.

**TESTING**
1. Set `DiscordClient.GatewayIntents = discordgo.IntentsNone`
2. No messages will be processed, as Discord won't send them, since we didn't ask for them.