### PR TITLE
Shorten ResolveGuildID when it exists on the original message

### DIFF
--- a/message.go
+++ b/message.go
@@ -106,6 +106,10 @@ func (m *DiscordMessage) Timestamp() (time.Time, error) {
 
 // ResolveGuildID resolves the GuildID from the message channel
 func (m *DiscordMessage) ResolveGuildID() (string, error) {
+	if m.DiscordgoMessage.GuildID != "" {
+		return m.DiscordgoMessage.GuildID, nil
+	}
+
 	channel, err := m.ResolveMessageChannel()
 
 	if err != nil {


### PR DESCRIPTION
**WHAT**
- Short circuits DiscordMessage.ResolveGuildID when the DiscordgoMessage includes the GuildID

**WHY**
- Not including the Guilds intent will make the channel resolution fail due to state issues, thus making this call fail too.