### PR TITLE
chore: bump discordgo to v0.23.2

### DIFF
--- a/client.go
+++ b/client.go
@@ -437,7 +437,7 @@ func (d *DiscordClient) Guilds() []*discordgo.Guild {
 }
 
 // UserChannelPermissions returns the permissions for a user in a channel
-func (d *DiscordClient) UserChannelPermissions(userID, channelID string) (apermissions int, err error) {
+func (d *DiscordClient) UserChannelPermissions(userID, channelID string) (apermissions int64, err error) {
 	for _, s := range d.Sessions {
 		apermissions, err = s.State.UserChannelPermissions(userID, channelID)
 		if err == nil {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/lampjaw/discordclient
 
 go 1.15
 
-require github.com/bwmarrin/discordgo v0.22.0
+require github.com/bwmarrin/discordgo v0.23.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/bwmarrin/discordgo v0.22.0 h1:uBxY1HmlVCsW1IuaPjpCGT6A2DBwRn0nvOguQIxDdFM=
 github.com/bwmarrin/discordgo v0.22.0/go.mod h1:c1WtWUGN6nREDmzIpyTp/iD3VYt4Fpx+bVyfBG7JE+M=
+github.com/bwmarrin/discordgo v0.23.2 h1:BzrtTktixGHIu9Tt7dEE6diysEF9HWnXeHuoJEt2fH4=
+github.com/bwmarrin/discordgo v0.23.2/go.mod h1:c1WtWUGN6nREDmzIpyTp/iD3VYt4Fpx+bVyfBG7JE+M=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16 h1:y6ce7gCWtnH+m3dCjzQ1PCuwl28DDIc3VNnvY29DlIA=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/bwmarrin/discordgo v0.22.0 h1:uBxY1HmlVCsW1IuaPjpCGT6A2DBwRn0nvOguQIxDdFM=
-github.com/bwmarrin/discordgo v0.22.0/go.mod h1:c1WtWUGN6nREDmzIpyTp/iD3VYt4Fpx+bVyfBG7JE+M=
 github.com/bwmarrin/discordgo v0.23.2 h1:BzrtTktixGHIu9Tt7dEE6diysEF9HWnXeHuoJEt2fH4=
 github.com/bwmarrin/discordgo v0.23.2/go.mod h1:c1WtWUGN6nREDmzIpyTp/iD3VYt4Fpx+bVyfBG7JE+M=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=


### PR DESCRIPTION
**WHAT**
- Bumps discordgo to v0.23.2
- Fixes permissions type to `int64` from `int` as library changed it. 